### PR TITLE
Removing add_subdirectory from main CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_subdirectory(custom_messages)
-add_subdirectory(custom_services)
+#add_subdirectory(custom_messages)
+#add_subdirectory(custom_services)


### PR DESCRIPTION
Removing add_subdirectory from main CMakeLists: compilation fails otherwise